### PR TITLE
Replace xargs with awk to Handle Names with Apostrophes

### DIFF
--- a/git-coauthors
+++ b/git-coauthors
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-git shortlog -sne | cut -f2- | xargs -I @ echo 'Co-authored-by: @'
+git shortlog -sne | cut -f2- | awk '{ print "Co-authored-by: " $0; }'


### PR DESCRIPTION
Name with apostrophes in them (for example `John O'Neill <john@oneill.com>`) cause xargs to fail with:
```
xargs: unterminated quote
```

Replace xargs with awk which provides the same functionality but can handle apostrophes.